### PR TITLE
Create SecureRng trait alias

### DIFF
--- a/scicrypt-he/src/cryptosystems/curve_el_gamal.rs
+++ b/scicrypt-he/src/cryptosystems/curve_el_gamal.rs
@@ -3,6 +3,7 @@ use curve25519_dalek::constants::RISTRETTO_BASEPOINT_TABLE;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;
 use scicrypt_traits::cryptosystems::AsymmetricCryptosystem;
+use scicrypt_traits::randomness::GeneralRng;
 use scicrypt_traits::randomness::SecureRng;
 use scicrypt_traits::security::BitsOfSecurity;
 use scicrypt_traits::Enrichable;
@@ -65,9 +66,9 @@ impl AsymmetricCryptosystem<'_> for CurveElGamal {
     type PublicKey = RistrettoPoint;
     type SecretKey = Scalar;
 
-    fn generate_keys<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn generate_keys<R: SecureRng>(
         security_param: &BitsOfSecurity,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> (Self::PublicKey, Self::SecretKey) {
         match security_param {
             BitsOfSecurity::AES128 => (),
@@ -82,10 +83,10 @@ impl AsymmetricCryptosystem<'_> for CurveElGamal {
         (public_key, secret_key)
     }
 
-    fn encrypt<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn encrypt<R: SecureRng>(
         plaintext: &Self::Plaintext,
         public_key: &Self::PublicKey,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> Self::Ciphertext {
         let y = Scalar::random(rng.rng());
 
@@ -133,12 +134,12 @@ mod tests {
     use curve25519_dalek::scalar::Scalar;
     use rand_core::OsRng;
     use scicrypt_traits::cryptosystems::AsymmetricCryptosystem;
-    use scicrypt_traits::randomness::SecureRng;
+    use scicrypt_traits::randomness::GeneralRng;
     use scicrypt_traits::Enrichable;
 
     #[test]
     fn test_encrypt_decrypt_generator() {
-        let mut rng = SecureRng::new(OsRng);
+        let mut rng = GeneralRng::new(OsRng);
 
         let (pk, sk) = CurveElGamal::generate_keys(&Default::default(), &mut rng);
 
@@ -152,7 +153,7 @@ mod tests {
 
     #[test]
     fn test_probabilistic_encryption() {
-        let mut rng = SecureRng::new(OsRng);
+        let mut rng = GeneralRng::new(OsRng);
 
         let (pk, _) = CurveElGamal::generate_keys(&Default::default(), &mut rng);
 
@@ -164,7 +165,7 @@ mod tests {
 
     #[test]
     fn test_homomorphic_add() {
-        let mut rng = SecureRng::new(OsRng);
+        let mut rng = GeneralRng::new(OsRng);
 
         let (pk, sk) = CurveElGamal::generate_keys(&Default::default(), &mut rng);
 
@@ -179,7 +180,7 @@ mod tests {
 
     #[test]
     fn test_homomorphic_scalar_mul() {
-        let mut rng = SecureRng::new(OsRng);
+        let mut rng = GeneralRng::new(OsRng);
 
         let (pk, sk) = CurveElGamal::generate_keys(&Default::default(), &mut rng);
 

--- a/scicrypt-he/src/cryptosystems/paillier.rs
+++ b/scicrypt-he/src/cryptosystems/paillier.rs
@@ -1,6 +1,7 @@
 use rug::Integer;
 use scicrypt_numbertheory::{gen_coprime, gen_rsa_modulus};
 use scicrypt_traits::cryptosystems::AsymmetricCryptosystem;
+use scicrypt_traits::randomness::GeneralRng;
 use scicrypt_traits::randomness::SecureRng;
 use scicrypt_traits::security::BitsOfSecurity;
 use scicrypt_traits::Enrichable;
@@ -51,17 +52,17 @@ impl AsymmetricCryptosystem<'_> for Paillier {
 
     /// Generates a fresh Paillier keypair.
     /// ```
-    /// # use scicrypt_traits::randomness::SecureRng;
+    /// # use scicrypt_traits::randomness::GeneralRng;
     /// # use scicrypt_he::cryptosystems::paillier::Paillier;
     /// # use scicrypt_traits::security::BitsOfSecurity;
     /// # use scicrypt_traits::cryptosystems::AsymmetricCryptosystem;
     /// # use rand_core::OsRng;
-    /// let mut rng = SecureRng::new(OsRng);
+    /// let mut rng = GeneralRng::new(OsRng);
     /// let (public_key, secret_key) = Paillier::generate_keys(&BitsOfSecurity::Other {pk_bits: 160}, &mut rng);
     /// ```
-    fn generate_keys<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn generate_keys<R: SecureRng>(
         security_param: &BitsOfSecurity,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> (Self::PublicKey, Self::SecretKey) {
         let (n, lambda) = gen_rsa_modulus(security_param.to_public_key_bit_length(), rng);
 
@@ -73,20 +74,20 @@ impl AsymmetricCryptosystem<'_> for Paillier {
 
     /// Encrypts a plaintext integer using the Paillier public key.
     /// ```
-    /// # use scicrypt_traits::randomness::SecureRng;
+    /// # use scicrypt_traits::randomness::GeneralRng;
     /// # use scicrypt_he::cryptosystems::paillier::Paillier;
     /// # use scicrypt_traits::security::BitsOfSecurity;
     /// # use scicrypt_traits::cryptosystems::AsymmetricCryptosystem;
     /// # use rug::Integer;
     /// # use rand_core::OsRng;
-    /// # let mut rng = SecureRng::new(OsRng);
+    /// # let mut rng = GeneralRng::new(OsRng);
     /// # let (public_key, secret_key) = Paillier::generate_keys(&BitsOfSecurity::Other {pk_bits: 160}, &mut rng);
     /// let ciphertext = Paillier::encrypt(&Integer::from(5), &public_key, &mut rng);
     /// ```
-    fn encrypt<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn encrypt<R: SecureRng>(
         plaintext: &Self::Plaintext,
         public_key: &Self::PublicKey,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> Self::Ciphertext {
         let n_squared = Integer::from(public_key.n.square_ref());
         let r = gen_coprime(&n_squared, rng);
@@ -101,14 +102,14 @@ impl AsymmetricCryptosystem<'_> for Paillier {
 
     /// Decrypts a rich Paillier ciphertext using the secret key.
     /// ```
-    /// # use scicrypt_traits::randomness::SecureRng;
+    /// # use scicrypt_traits::randomness::GeneralRng;
     /// # use scicrypt_he::cryptosystems::paillier::Paillier;
     /// # use scicrypt_traits::security::BitsOfSecurity;
     /// # use scicrypt_traits::cryptosystems::AsymmetricCryptosystem;
     /// # use scicrypt_traits::Enrichable;
     /// # use rug::Integer;
     /// # use rand_core::OsRng;
-    /// # let mut rng = SecureRng::new(OsRng);
+    /// # let mut rng = GeneralRng::new(OsRng);
     /// # let (public_key, secret_key) = Paillier::generate_keys(&BitsOfSecurity::Other {pk_bits: 160}, &mut rng);
     /// # let ciphertext = Paillier::encrypt(&Integer::from(5), &public_key, &mut rng);
     /// let rich_ciphertext = ciphertext.enrich(&public_key);
@@ -172,13 +173,13 @@ mod tests {
     use rand_core::OsRng;
     use rug::Integer;
     use scicrypt_traits::cryptosystems::AsymmetricCryptosystem;
-    use scicrypt_traits::randomness::SecureRng;
+    use scicrypt_traits::randomness::GeneralRng;
     use scicrypt_traits::security::BitsOfSecurity;
     use scicrypt_traits::Enrichable;
 
     #[test]
     fn test_encrypt_decrypt() {
-        let mut rng = SecureRng::new(OsRng);
+        let mut rng = GeneralRng::new(OsRng);
 
         let (pk, sk) = Paillier::generate_keys(&BitsOfSecurity::Other { pk_bits: 160 }, &mut rng);
 
@@ -192,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_homomorphic_add() {
-        let mut rng = SecureRng::new(OsRng);
+        let mut rng = GeneralRng::new(OsRng);
 
         let (pk, sk) = Paillier::generate_keys(&BitsOfSecurity::Other { pk_bits: 160 }, &mut rng);
 
@@ -204,7 +205,7 @@ mod tests {
 
     #[test]
     fn test_homomorphic_scalar_mul() {
-        let mut rng = SecureRng::new(OsRng);
+        let mut rng = GeneralRng::new(OsRng);
 
         let (pk, sk) = Paillier::generate_keys(&BitsOfSecurity::Other { pk_bits: 160 }, &mut rng);
 

--- a/scicrypt-he/src/threshold_cryptosystems/curve_el_gamal.rs
+++ b/scicrypt-he/src/threshold_cryptosystems/curve_el_gamal.rs
@@ -2,6 +2,7 @@ use crate::cryptosystems::curve_el_gamal::{CurveElGamalCiphertext, RichCurveElGa
 use curve25519_dalek::constants::RISTRETTO_BASEPOINT_TABLE;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;
+use scicrypt_traits::randomness::GeneralRng;
 use scicrypt_traits::randomness::SecureRng;
 use scicrypt_traits::security::BitsOfSecurity;
 use scicrypt_traits::threshold_cryptosystems::{
@@ -21,10 +22,10 @@ impl AsymmetricNOfNCryptosystem for NOfNCurveElGamal {
     type PartialKey = Scalar;
     type DecryptionShare = (RistrettoPoint, RistrettoPoint);
 
-    fn generate_keys<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn generate_keys<R: SecureRng>(
         security_param: &BitsOfSecurity,
         key_count_n: usize,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> (Self::PublicKey, Vec<Self::PartialKey>) {
         match security_param {
             BitsOfSecurity::AES128 => (),
@@ -43,10 +44,10 @@ impl AsymmetricNOfNCryptosystem for NOfNCurveElGamal {
         (public_key, partial_keys)
     }
 
-    fn encrypt<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn encrypt<R: SecureRng>(
         plaintext: &Self::Plaintext,
         public_key: &Self::PublicKey,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> Self::Ciphertext {
         let y = Scalar::random(rng.rng());
 
@@ -100,11 +101,11 @@ impl AsymmetricTOfNCryptosystem for TOfNCurveElGamal {
     type PartialKey = TOfNCurveElGamalPartialKey;
     type DecryptionShare = TOfNCurveElGamalDecryptionShare;
 
-    fn generate_keys<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn generate_keys<R: SecureRng>(
         security_param: &BitsOfSecurity,
         threshold_t: usize,
         key_count_n: usize,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> (Self::PublicKey, Vec<Self::PartialKey>) {
         match security_param {
             BitsOfSecurity::AES128 => (),
@@ -134,10 +135,10 @@ impl AsymmetricTOfNCryptosystem for TOfNCurveElGamal {
         (&master_key * &RISTRETTO_BASEPOINT_TABLE, partial_keys)
     }
 
-    fn encrypt<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn encrypt<R: SecureRng>(
         plaintext: &Self::Plaintext,
         public_key: &Self::PublicKey,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> Self::Ciphertext {
         let y = Scalar::random(rng.rng());
 
@@ -197,7 +198,7 @@ mod tests {
     use curve25519_dalek::constants::RISTRETTO_BASEPOINT_TABLE;
     use curve25519_dalek::scalar::Scalar;
     use rand_core::OsRng;
-    use scicrypt_traits::randomness::SecureRng;
+    use scicrypt_traits::randomness::GeneralRng;
     use scicrypt_traits::security::BitsOfSecurity;
     use scicrypt_traits::threshold_cryptosystems::{
         AsymmetricNOfNCryptosystem, AsymmetricTOfNCryptosystem,
@@ -206,7 +207,7 @@ mod tests {
 
     #[test]
     fn test_encrypt_decrypt_3_of_3() {
-        let mut rng = SecureRng::new(OsRng);
+        let mut rng = GeneralRng::new(OsRng);
 
         let (pk, sks) = NOfNCurveElGamal::generate_keys(&BitsOfSecurity::default(), 3, &mut rng);
 
@@ -226,7 +227,7 @@ mod tests {
 
     #[test]
     fn test_encrypt_decrypt_2_of_3() {
-        let mut rng = SecureRng::new(OsRng);
+        let mut rng = GeneralRng::new(OsRng);
 
         let (pk, sks) = TOfNCurveElGamal::generate_keys(&BitsOfSecurity::default(), 2, 3, &mut rng);
 

--- a/scicrypt-he/src/threshold_cryptosystems/integer_el_gamal.rs
+++ b/scicrypt-he/src/threshold_cryptosystems/integer_el_gamal.rs
@@ -3,6 +3,7 @@ use crate::cryptosystems::integer_el_gamal::{
 };
 use rug::Integer;
 use scicrypt_numbertheory::gen_safe_prime;
+use scicrypt_traits::randomness::GeneralRng;
 use scicrypt_traits::randomness::SecureRng;
 use scicrypt_traits::security::BitsOfSecurity;
 use scicrypt_traits::threshold_cryptosystems::{
@@ -23,10 +24,10 @@ impl AsymmetricNOfNCryptosystem for NOfNIntegerElGamal {
     type PartialKey = Integer;
     type DecryptionShare = (Integer, Integer);
 
-    fn generate_keys<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn generate_keys<R: SecureRng>(
         security_param: &BitsOfSecurity,
         key_count_n: usize,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> (Self::PublicKey, Vec<Self::PartialKey>) {
         let modulus = gen_safe_prime(security_param.to_public_key_bit_length(), rng);
 
@@ -46,10 +47,10 @@ impl AsymmetricNOfNCryptosystem for NOfNIntegerElGamal {
         )
     }
 
-    fn encrypt<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn encrypt<R: SecureRng>(
         plaintext: &Self::Plaintext,
         public_key: &Self::PublicKey,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> Self::Ciphertext {
         let q = Integer::from(&public_key.modulus >> 1);
         let y = q.random_below(&mut rng.rug_rng());
@@ -119,11 +120,11 @@ impl AsymmetricTOfNCryptosystem for TOfNIntegerElGamal {
     type PartialKey = TOfNIntegerElGamalPartialKey;
     type DecryptionShare = TOfNIntegerElGamalDecryptionShare;
 
-    fn generate_keys<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn generate_keys<R: SecureRng>(
         security_param: &BitsOfSecurity,
         threshold_t: usize,
         key_count_n: usize,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> (Self::PublicKey, Vec<Self::PartialKey>) {
         let modulus = gen_safe_prime(security_param.to_public_key_bit_length(), rng);
 
@@ -160,10 +161,10 @@ impl AsymmetricTOfNCryptosystem for TOfNIntegerElGamal {
         )
     }
 
-    fn encrypt<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn encrypt<R: SecureRng>(
         plaintext: &Self::Plaintext,
         public_key: &Self::PublicKey,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> Self::Ciphertext {
         let q = Integer::from(&public_key.modulus >> 1);
         let y = q.random_below(&mut rng.rug_rng());
@@ -241,7 +242,7 @@ mod tests {
     };
     use rand_core::OsRng;
     use rug::Integer;
-    use scicrypt_traits::randomness::SecureRng;
+    use scicrypt_traits::randomness::GeneralRng;
     use scicrypt_traits::security::BitsOfSecurity;
     use scicrypt_traits::threshold_cryptosystems::{
         AsymmetricNOfNCryptosystem, AsymmetricTOfNCryptosystem,
@@ -250,7 +251,7 @@ mod tests {
 
     #[test]
     fn test_encrypt_decrypt_3_of_3() {
-        let mut rng = SecureRng::new(OsRng);
+        let mut rng = GeneralRng::new(OsRng);
 
         let (pk, sks) =
             NOfNIntegerElGamal::generate_keys(&BitsOfSecurity::Other { pk_bits: 160 }, 3, &mut rng);
@@ -271,7 +272,7 @@ mod tests {
 
     #[test]
     fn test_encrypt_decrypt_2_of_3() {
-        let mut rng = SecureRng::new(OsRng);
+        let mut rng = GeneralRng::new(OsRng);
 
         let (pk, sks) = TOfNIntegerElGamal::generate_keys(
             &BitsOfSecurity::Other { pk_bits: 160 },

--- a/scicrypt-numbertheory/benches/prime_gen.rs
+++ b/scicrypt-numbertheory/benches/prime_gen.rs
@@ -6,7 +6,7 @@ use openssl::bn::BigNum;
 use rand::rngs;
 use rand_core::OsRng;
 use scicrypt_numbertheory::gen_safe_prime;
-use scicrypt_traits::randomness::SecureRng;
+use scicrypt_traits::randomness::GeneralRng;
 
 pub fn safe_prime_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("safe_prime_benchmark");
@@ -16,7 +16,7 @@ pub fn safe_prime_benchmark(c: &mut Criterion) {
         //group.throughput(Throughput::Bytes(*bit_length as u64));
 
         // Benchmark our `gen_safe_prime` function
-        let mut rng = SecureRng::new(OsRng);
+        let mut rng = GeneralRng::new(OsRng);
         group.bench_with_input(
             BenchmarkId::new("gen_safe_prime", bit_length),
             bit_length,

--- a/scicrypt-numbertheory/src/lib.rs
+++ b/scicrypt-numbertheory/src/lib.rs
@@ -11,16 +11,14 @@ mod primes;
 use crate::primes::FIRST_PRIMES;
 use rug::integer::IsPrime;
 use rug::Integer;
+use scicrypt_traits::randomness::GeneralRng;
 use scicrypt_traits::randomness::SecureRng;
 
 const REPS: u32 = 25;
 
 /// Generates a uniformly random prime number of a given bit length. So, the number contains
 /// `bit_length` bits, of which the first and the last bit are always 1.
-pub fn gen_prime<R: rand_core::RngCore + rand_core::CryptoRng>(
-    bit_length: u32,
-    rng: &mut SecureRng<R>,
-) -> Integer {
+pub fn gen_prime<R: SecureRng>(bit_length: u32, rng: &mut GeneralRng<R>) -> Integer {
     'outer: loop {
         let mut candidate = Integer::from(Integer::random_bits(bit_length, &mut rng.rug_rng()));
         candidate.set_bit(bit_length - 1, true);
@@ -63,10 +61,7 @@ pub fn gen_prime<R: rand_core::RngCore + rand_core::CryptoRng>(
 
 /// Generates a uniformly random *safe* prime number of a given bit length. This is a prime $p$ of
 /// the form $p = 2q + 1$, where $q$ is a smaller prime.
-pub fn gen_safe_prime<R: rand_core::RngCore + rand_core::CryptoRng>(
-    bit_length: u32,
-    rng: &mut SecureRng<R>,
-) -> Integer {
+pub fn gen_safe_prime<R: SecureRng>(bit_length: u32, rng: &mut GeneralRng<R>) -> Integer {
     'outer: loop {
         let mut candidate = Integer::from(Integer::random_bits(bit_length, &mut rng.rug_rng()));
         candidate.set_bit(bit_length - 1, true);
@@ -114,9 +109,9 @@ pub fn gen_safe_prime<R: rand_core::RngCore + rand_core::CryptoRng>(
 /// Generates a uniformly random RSA modulus, which is the product of two safe primes $p$ and $q$.
 /// This method returns both the modulus and $\lambda$, which is the least common multiple of
 /// $p - 1$ and $q - 1$.
-pub fn gen_rsa_modulus<R: rand_core::RngCore + rand_core::CryptoRng>(
+pub fn gen_rsa_modulus<R: SecureRng>(
     bit_length: u32,
-    rng: &mut SecureRng<R>,
+    rng: &mut GeneralRng<R>,
 ) -> (Integer, Integer) {
     let p = gen_safe_prime(bit_length / 2, rng);
     let q = gen_safe_prime(bit_length / 2, rng);
@@ -130,10 +125,7 @@ pub fn gen_rsa_modulus<R: rand_core::RngCore + rand_core::CryptoRng>(
 
 /// Generates a uniformly random coprime $x$ to the `other` integer $y$. This means that
 /// $\gcd(x, y) = 1$.
-pub fn gen_coprime<R: rand_core::RngCore + rand_core::CryptoRng>(
-    other: &Integer,
-    rng: &mut SecureRng<R>,
-) -> Integer {
+pub fn gen_coprime<R: SecureRng>(other: &Integer, rng: &mut GeneralRng<R>) -> Integer {
     loop {
         let candidate = Integer::from(other.random_below_ref(&mut rng.rug_rng()));
 
@@ -148,7 +140,7 @@ mod tests {
     use crate::{gen_prime, gen_safe_prime};
     use rand_core::OsRng;
     use rug::Integer;
-    use scicrypt_traits::randomness::SecureRng;
+    use scicrypt_traits::randomness::GeneralRng;
 
     fn assert_primality_100_000_factors(integer: &Integer) {
         let (_, hi) = primal::estimate_nth_prime(100_000);
@@ -164,7 +156,7 @@ mod tests {
 
     #[test]
     fn test_gen_prime_for_factors() {
-        let mut rng = SecureRng::new(OsRng);
+        let mut rng = GeneralRng::new(OsRng);
         let generated_prime = gen_prime(256, &mut rng);
 
         assert_primality_100_000_factors(&generated_prime);
@@ -172,7 +164,7 @@ mod tests {
 
     #[test]
     fn test_gen_safe_prime_for_factors() {
-        let mut rng = SecureRng::new(OsRng);
+        let mut rng = GeneralRng::new(OsRng);
         let generated_prime = gen_safe_prime(256, &mut rng);
 
         assert_primality_100_000_factors(&generated_prime);

--- a/scicrypt-traits/src/cryptosystems.rs
+++ b/scicrypt-traits/src/cryptosystems.rs
@@ -1,3 +1,4 @@
+use crate::randomness::GeneralRng;
 use crate::randomness::SecureRng;
 use crate::security::BitsOfSecurity;
 use crate::Enrichable;
@@ -25,16 +26,16 @@ pub trait AsymmetricCryptosystem<'pk> {
 
     /// Generate a public and private key pair using a cryptographic RNG. The level of security is
     /// determined by the computational `security_param`.
-    fn generate_keys<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn generate_keys<R: SecureRng>(
         security_param: &BitsOfSecurity,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> (Self::PublicKey, Self::SecretKey);
 
     /// Encrypt the plaintext using the public key and a cryptographic RNG.
-    fn encrypt<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn encrypt<R: SecureRng>(
         plaintext: &Self::Plaintext,
         public_key: &Self::PublicKey,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> Self::Ciphertext;
 
     /// Decrypt the ciphertext using the secret key and its related public key.

--- a/scicrypt-traits/src/lib.rs
+++ b/scicrypt-traits/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(generic_associated_types)]
-// This is necessary for now, hopefully we can go back to stable around October
+#![feature(trait_alias)]
+// This is necessary for now, hopefully we can go back to stable in the future
 #![warn(missing_docs, unused_imports)]
 
 //! _This is a part of **scicrypt**. For more information, head to the

--- a/scicrypt-traits/src/randomness.rs
+++ b/scicrypt-traits/src/randomness.rs
@@ -1,15 +1,17 @@
 use rug::rand::{ThreadRandGen, ThreadRandState};
 
+pub trait SecureRng = rand_core::RngCore + rand_core::CryptoRng;
+
 /// General RNG that can be used for all dependencies.
-pub struct SecureRng<R: rand_core::RngCore + rand_core::CryptoRng> {
+pub struct GeneralRng<R: SecureRng> {
     rng_wrapper: RngWrapper<R>,
 }
 
-impl<R: rand_core::RngCore + rand_core::CryptoRng> SecureRng<R> {
+impl<R: SecureRng> GeneralRng<R> {
     /// Creates a new `SecureRng` based on an RNG that implements both `RngCore` and `CryptoRng` to
     /// ensure that the underlying RNG is indeed cryptographically secure.
     pub fn new(rng: R) -> Self {
-        SecureRng {
+        GeneralRng {
             rng_wrapper: RngWrapper { rng },
         }
     }
@@ -25,11 +27,11 @@ impl<R: rand_core::RngCore + rand_core::CryptoRng> SecureRng<R> {
     }
 }
 
-struct RngWrapper<R: rand_core::RngCore + rand_core::CryptoRng> {
+struct RngWrapper<R: SecureRng> {
     rng: R,
 }
 
-impl<R: rand_core::RngCore + rand_core::CryptoRng> ThreadRandGen for RngWrapper<R> {
+impl<R: SecureRng> ThreadRandGen for RngWrapper<R> {
     fn gen(&mut self) -> u32 {
         self.rng.next_u32()
     }

--- a/scicrypt-traits/src/threshold_cryptosystems.rs
+++ b/scicrypt-traits/src/threshold_cryptosystems.rs
@@ -1,3 +1,4 @@
+use crate::randomness::GeneralRng;
 use crate::randomness::SecureRng;
 use crate::security::BitsOfSecurity;
 use crate::DecryptionError;
@@ -35,17 +36,17 @@ pub trait AsymmetricNOfNCryptosystem {
     type DecryptionShare;
 
     /// Generate a public and private key pair using a cryptographic RNG.
-    fn generate_keys<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn generate_keys<R: SecureRng>(
         security_param: &BitsOfSecurity,
         key_count_n: usize,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> (Self::PublicKey, Vec<Self::PartialKey>);
 
     /// Encrypt the plaintext using the public key and a cryptographic RNG.
-    fn encrypt<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn encrypt<R: SecureRng>(
         plaintext: &Self::Plaintext,
         public_key: &Self::PublicKey,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> Self::Ciphertext;
 
     /// Partially decrypt the ciphertext using a partial key and its related public key.
@@ -95,18 +96,18 @@ pub trait AsymmetricTOfNCryptosystem {
     type DecryptionShare;
 
     /// Generate a public and private key pair using a cryptographic RNG.
-    fn generate_keys<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn generate_keys<R: SecureRng>(
         security_param: &BitsOfSecurity,
         threshold_t: usize,
         key_count_n: usize,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> (Self::PublicKey, Vec<Self::PartialKey>);
 
     /// Encrypt the plaintext using the public key and a cryptographic RNG.
-    fn encrypt<R: rand_core::RngCore + rand_core::CryptoRng>(
+    fn encrypt<R: SecureRng>(
         plaintext: &Self::Plaintext,
         public_key: &Self::PublicKey,
-        rng: &mut SecureRng<R>,
+        rng: &mut GeneralRng<R>,
     ) -> Self::Ciphertext;
 
     /// Partially decrypt the ciphertext using a partial key and its related public key.


### PR DESCRIPTION
This trait alias makes it so we do not constantly have to repeat the defining subtraits, and it reduces the chance of version mismatch. The previous struct called 'SecureRng' is now 'GeneralRng', as its functionality is actually to function as an adapter for an Rng between `rug` and `curve25519-dalek`.