### PR TITLE
Fix open TODOs in code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "scicrypt-he"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "curve25519-dalek",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "scicrypt-numbertheory"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "glass_pumpkin",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "scicrypt-traits"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "rand_core",
  "rug",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "scicrypt"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "scicrypt-he",
  "scicrypt-numbertheory",

--- a/scicrypt-he/Cargo.toml
+++ b/scicrypt-he/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scicrypt-he"
 description = "A scicrypt crate implementing several well-known partially homomorphic (threshold) cryptosystems"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Jelle Vos <scicrypt@jelle-vos.nl>"]
 edition = "2018"
 license = "MIT"

--- a/scicrypt-he/Cargo.toml
+++ b/scicrypt-he/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 bench = false  # Disable default bench (we use criterion)
 
 [dependencies]
-scicrypt-traits = { version = "0.5.0", path = "../scicrypt-traits" }
-scicrypt-numbertheory = { version = "0.5.0", path = "../scicrypt-numbertheory" }
+scicrypt-traits = { version = "0.6.0", path = "../scicrypt-traits" }
+scicrypt-numbertheory = { version = "0.6.0", path = "../scicrypt-numbertheory" }
 curve25519-dalek = "4.0.0-pre.2"
 rug = "1.13"
 rand_core = "0.6"

--- a/scicrypt-he/src/cryptosystems/curve_el_gamal.rs
+++ b/scicrypt-he/src/cryptosystems/curve_el_gamal.rs
@@ -136,7 +136,6 @@ impl EncryptionKey for PrecomputedCurveElGamalPK {
     }
 }
 
-// TODO: These double definitions can be made into one generic if associated ciphertexts have a trait
 impl DecryptionKey<CurveElGamalPK> for CurveElGamalSK {
     fn decrypt_raw(
         &self,

--- a/scicrypt-he/src/cryptosystems/paillier.rs
+++ b/scicrypt-he/src/cryptosystems/paillier.rs
@@ -30,7 +30,7 @@ pub struct PaillierSK {
 
 /// Ciphertext of the Paillier cryptosystem, which is additively homomorphic.
 pub struct PaillierCiphertext {
-    c: Integer,
+    pub(crate) c: Integer,
 }
 
 impl Associable<PaillierPK> for PaillierCiphertext {}

--- a/scicrypt-numbertheory/Cargo.toml
+++ b/scicrypt-numbertheory/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 bench = false  # Disable default bench (we use criterion)
 
 [dependencies]
-scicrypt-traits = { version = "0.5.0", path = "../scicrypt-traits" }
+scicrypt-traits = { version = "0.6.0", path = "../scicrypt-traits" }
 rug = "1.13"
 rand_core = "0.6"
 

--- a/scicrypt-numbertheory/Cargo.toml
+++ b/scicrypt-numbertheory/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scicrypt-numbertheory"
 description = "A scicrypt crate implementing number theoretic algorithms such as random (safe) prime generation"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Jelle Vos <scicrypt@jelle-vos.nl>"]
 edition = "2018"
 license = "MIT"

--- a/scicrypt-traits/Cargo.toml
+++ b/scicrypt-traits/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scicrypt-traits"
 description = "A scicrypt crate defining general traits for cryptographic systems and functionalities"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Jelle Vos <scicrypt@jelle-vos.nl>"]
 edition = "2018"
 license = "MIT"

--- a/scicrypt-traits/src/homomorphic.rs
+++ b/scicrypt-traits/src/homomorphic.rs
@@ -59,7 +59,6 @@ pub trait HomomorphicMultiplication: EncryptionKey {
     fn pow(&self, ciphertext: Self::Ciphertext, input: Self::Input) -> Self::Ciphertext;
 }
 
-// TODO: This leads to problems because PK::Plaintext can be AssociatedCiphertext<'pk, C, PK>
 impl<'pk, C: Associable<PK>, PK: EncryptionKey<Ciphertext = C> + HomomorphicMultiplication> Mul
     for AssociatedCiphertext<'pk, C, PK>
 {

--- a/scicrypt/Cargo.toml
+++ b/scicrypt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scicrypt"
 description = "Lightweight cryptographic building blocks for proof of concept implementations in multi-party computation"
-version = "0.5.0"  # In sync with `scicrypt-traits`, `scicrypt-numbertheory`, and `scicrypt-he`
+version = "0.6.0"  # In sync with `scicrypt-traits`, `scicrypt-numbertheory`, and `scicrypt-he`
 authors = ["Jelle Vos <scicrypt@jelle-vos.nl>"]
 edition = "2018"
 license = "MIT"

--- a/scicrypt/Cargo.toml
+++ b/scicrypt/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 bench = false  # Disable default bench (we use criterion)
 
 [dependencies]
-scicrypt-traits = { version = "0.5.0", path = "../scicrypt-traits" }
-scicrypt-numbertheory = { version = "0.5.0", path = "../scicrypt-numbertheory" }
-scicrypt-he = { version = "0.5.0", path = "../scicrypt-he" }
+scicrypt-traits = { version = "0.6.0", path = "../scicrypt-traits" }
+scicrypt-numbertheory = { version = "0.6.0", path = "../scicrypt-numbertheory" }
+scicrypt-he = { version = "0.6.0", path = "../scicrypt-he" }
 
 [package.metadata.docs.rs]
 rustdoc-args = [ "--html-in-header", "katex-header.html" ]


### PR DESCRIPTION
Now threshold Paillier uses standard Paillier ciphertexts.