### PR TITLE
Optimize homomorphic encryption (precomputations and other optimizations)

### DIFF
--- a/scicrypt-he/src/cryptosystems/paillier.rs
+++ b/scicrypt-he/src/cryptosystems/paillier.rs
@@ -58,7 +58,7 @@ impl AsymmetricCryptosystem for Paillier {
     /// let (public_key, secret_key) = paillier.generate_keys(&mut rng);
     /// ```
     fn generate_keys<R: SecureRng>(&self, rng: &mut GeneralRng<R>) -> (PaillierPK, PaillierSK) {
-        let (n, lambda) = gen_rsa_modulus(self.modulus_size, rng);
+        let (n, lambda, _, _) = gen_rsa_modulus(self.modulus_size, rng);
 
         let g = &n + Integer::from(1);
         let mu = Integer::from(lambda.invert_ref(&n).unwrap());
@@ -142,7 +142,12 @@ impl DecryptionKey<PaillierPK> for PaillierSK {
         // 0 also only occurs with extremely low probability, so we can simply sample randomly s.t. 0 < r < n
         let r = Integer::from(public_key.n.random_below_ref(&mut rng.rug_rng()));
 
-        let first = Integer::from(public_key.g.pow_mod_ref(plaintext, &public_key.n_squared).unwrap());
+        let first = Integer::from(
+            public_key
+                .g
+                .pow_mod_ref(plaintext, &public_key.n_squared)
+                .unwrap(),
+        );
         let second = r.secure_pow_mod(&public_key.n, &public_key.n_squared);
 
         PaillierCiphertext {

--- a/scicrypt-numbertheory/src/lib.rs
+++ b/scicrypt-numbertheory/src/lib.rs
@@ -107,20 +107,20 @@ pub fn gen_safe_prime<R: SecureRng>(bit_length: u32, rng: &mut GeneralRng<R>) ->
 }
 
 /// Generates a uniformly random RSA modulus, which is the product of two safe primes $p$ and $q$.
-/// This method returns both the modulus and $\lambda$, which is the least common multiple of
+/// This method returns the modulus, $\lambda$, $p$, and $q$. $\lambda$ is the least common multiple of
 /// $p - 1$ and $q - 1$.
 pub fn gen_rsa_modulus<R: SecureRng>(
     bit_length: u32,
     rng: &mut GeneralRng<R>,
-) -> (Integer, Integer) {
+) -> (Integer, Integer, Integer, Integer) {
     let p = gen_safe_prime(bit_length / 2, rng);
     let q = gen_safe_prime(bit_length / 2, rng);
 
     let n = Integer::from(&p * &q);
 
-    let lambda: Integer = (p - Integer::from(1)).lcm(&(q - Integer::from(1)));
+    let lambda: Integer = (&p - Integer::from(1)).lcm(&(&q - Integer::from(1)));
 
-    (n, lambda)
+    (n, lambda, p, q)
 }
 
 /// Generates a uniformly random coprime $x$ to the `other` integer $y$. This means that

--- a/scicrypt-traits/src/cryptosystems.rs
+++ b/scicrypt-traits/src/cryptosystems.rs
@@ -67,6 +67,29 @@ pub trait DecryptionKey<PK: EncryptionKey> {
 
     /// Decrypt the ciphertext using the secret key and its related public key.
     fn decrypt_raw(&self, public_key: &PK, ciphertext: &PK::Ciphertext) -> PK::Plaintext;
+
+    /// Uses both the secret material from the decryption key and the encryption key to encrypt faster than with only the encryption key.
+    /// This method is always implemented, but it defaults to simply encrypting without the secret key.
+    fn encrypt_fast<'pk, R: SecureRng>(
+        &'pk self,
+        public_key: &'pk PK,
+        plaintext: &PK::Plaintext,
+        rng: &mut GeneralRng<R>,
+    ) -> AssociatedCiphertext<'pk, PK::Ciphertext, PK> {
+        self.encrypt_fast_raw(public_key, plaintext, rng)
+            .associate(public_key)
+    }
+
+    /// Uses both the secret material from the decryption key and the encryption key to encrypt faster than with only the encryption key.
+    /// This method is always implemented, but it defaults to simply encrypting without the secret key.
+    fn encrypt_fast_raw<R: SecureRng>(
+        &self,
+        public_key: &PK,
+        plaintext: &PK::Plaintext,
+        rng: &mut GeneralRng<R>,
+    ) -> PK::Ciphertext {
+        public_key.encrypt_raw(plaintext, rng)
+    }
 }
 
 #[derive(PartialEq, Debug)]


### PR DESCRIPTION
**Paillier:**
- Precomputed `n_squared`
- Sample r from [0, n) instead of generating a random coprime to `n_squared`
