### PR TITLE
Serde support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f771a5d1f5503f7f4279a30f3643d3421ba149848b89ecaaec0ea2acf04a5ac4"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +704,7 @@ dependencies = [
 name = "scicrypt-he"
 version = "0.6.0"
 dependencies = [
+ "bincode",
  "criterion",
  "curve25519-dalek",
  "rand_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
  "byteorder",
  "digest",
  "rand_core",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -654,6 +655,7 @@ dependencies = [
  "az",
  "gmp-mpfr-sys",
  "libc",
+ "serde",
 ]
 
 [[package]]
@@ -699,6 +701,7 @@ dependencies = [
  "rug",
  "scicrypt-numbertheory",
  "scicrypt-traits",
+ "serde",
 ]
 
 [[package]]
@@ -740,6 +743,9 @@ name = "serde"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_cbor"

--- a/scicrypt-he/Cargo.toml
+++ b/scicrypt-he/Cargo.toml
@@ -15,9 +15,10 @@ bench = false  # Disable default bench (we use criterion)
 [dependencies]
 scicrypt-traits = { version = "0.6.0", path = "../scicrypt-traits" }
 scicrypt-numbertheory = { version = "0.6.0", path = "../scicrypt-numbertheory" }
-curve25519-dalek = "4.0.0-pre.2"
-rug = "1.13"
+curve25519-dalek = { package = "curve25519-dalek", version = "4.0.0-pre.2", features = ["serde"] }
+rug = { version = "1.13", features = ["serde"]}
 rand_core = "0.6"
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/scicrypt-he/Cargo.toml
+++ b/scicrypt-he/Cargo.toml
@@ -19,6 +19,7 @@ curve25519-dalek = { package = "curve25519-dalek", version = "4.0.0-pre.2", feat
 rug = { version = "1.13", features = ["serde"]}
 rand_core = "0.6"
 serde = { version = "1.0", features = ["derive"] }
+bincode = "1.3.3"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/scicrypt-he/src/cryptosystems/curve_el_gamal.rs
+++ b/scicrypt-he/src/cryptosystems/curve_el_gamal.rs
@@ -215,8 +215,6 @@ impl HomomorphicAddition for PrecomputedCurveElGamalPK {
 #[cfg(test)]
 mod tests {
     use crate::cryptosystems::curve_el_gamal::CurveElGamal;
-    use crate::cryptosystems::curve_el_gamal::PrecomputedCurveElGamalPK;
-    use bincode::{deserialize, serialize};
     use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
     use curve25519_dalek::scalar::Scalar;
     use rand_core::OsRng;

--- a/scicrypt-he/src/cryptosystems/curve_el_gamal.rs
+++ b/scicrypt-he/src/cryptosystems/curve_el_gamal.rs
@@ -8,10 +8,7 @@ use scicrypt_traits::homomorphic::HomomorphicAddition;
 use scicrypt_traits::randomness::GeneralRng;
 use scicrypt_traits::randomness::SecureRng;
 use scicrypt_traits::security::BitsOfSecurity;
-use serde::de::{self, SeqAccess, Visitor};
-use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use std::fmt::{Debug, Formatter};
 
 /// ElGamal over the Ristretto-encoded Curve25519 elliptic curve. The curve is provided by the
@@ -49,6 +46,15 @@ impl CurveElGamalPK {
     pub fn precompute(self) -> PrecomputedCurveElGamalPK {
         PrecomputedCurveElGamalPK {
             point: RistrettoBasepointTable::create(&self.point),
+        }
+    }
+}
+
+impl PrecomputedCurveElGamalPK {
+    /// Compresses the encryption key down to a `CurveElGamalPK` which is slower but more compact. This is useful for serialization.
+    pub fn compress(self) -> CurveElGamalPK {
+        CurveElGamalPK {
+            point: self.point.basepoint(),
         }
     }
 }
@@ -124,50 +130,6 @@ impl Debug for PrecomputedCurveElGamalPK {
 impl PartialEq for PrecomputedCurveElGamalPK {
     fn eq(&self, other: &Self) -> bool {
         self.point.basepoint() == other.point.basepoint()
-    }
-}
-
-impl Serialize for PrecomputedCurveElGamalPK {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut state = serializer.serialize_struct("PrecomputedCurveElGamalPK", 1)?;
-        state.serialize_field("point", &self.point.basepoint())?;
-        state.end()
-    }
-}
-impl<'de> Deserialize<'de> for PrecomputedCurveElGamalPK {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct PrecomputedCurveElGamalPKVisitor;
-
-        impl<'de> Visitor<'de> for PrecomputedCurveElGamalPKVisitor {
-            type Value = PrecomputedCurveElGamalPK;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("struct PrecomputedCurveElGamalPK")
-            }
-
-            fn visit_seq<V>(self, mut seq: V) -> Result<PrecomputedCurveElGamalPK, V::Error>
-            where
-                V: SeqAccess<'de>,
-            {
-                let point = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                Ok(CurveElGamalPK { point }.precompute())
-            }
-        }
-
-        const FIELDS: &[&str] = &["point"];
-        deserializer.deserialize_struct(
-            "PrecomputedCurveElGamalPK",
-            FIELDS,
-            PrecomputedCurveElGamalPKVisitor,
-        )
     }
 }
 
@@ -317,19 +279,5 @@ mod tests {
             &Scalar::from(3u64) * &RISTRETTO_BASEPOINT_POINT,
             sk.decrypt(&ciphertext_thrice)
         );
-    }
-    #[test]
-    fn serialize_deserialize() {
-        let mut rng = GeneralRng::new(OsRng);
-
-        let el_gamal = CurveElGamal::setup(&Default::default());
-        let (pk, _sk) = el_gamal.generate_keys(&mut rng);
-
-        let pk_deserialized: PrecomputedCurveElGamalPK =
-            deserialize(&serialize(&pk).unwrap()).unwrap();
-        let (pk_new, _sk) = el_gamal.generate_keys(&mut rng);
-
-        assert_eq!(pk_deserialized.point.basepoint(), pk.point.basepoint());
-        assert_ne!(pk_new.point.basepoint(), pk_deserialized.point.basepoint());
     }
 }

--- a/scicrypt-he/src/cryptosystems/integer_el_gamal.rs
+++ b/scicrypt-he/src/cryptosystems/integer_el_gamal.rs
@@ -7,6 +7,7 @@ use scicrypt_traits::homomorphic::HomomorphicMultiplication;
 use scicrypt_traits::randomness::GeneralRng;
 use scicrypt_traits::randomness::SecureRng;
 use scicrypt_traits::security::BitsOfSecurity;
+use serde::{Deserialize, Serialize};
 use std::ops::Rem;
 
 /// Multiplicatively homomorphic ElGamal over a safe prime group where the generator is 4.
@@ -35,16 +36,21 @@ pub struct IntegerElGamal {
 }
 
 /// Public key containing the ElGamal encryption key and the modulus of the group.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct IntegerElGamalPK {
-    pub(crate) h: Integer,
-    pub(crate) modulus: Integer,
+    /// Generator for encrypting
+    pub h: Integer,
+    /// Modulus of public key
+    pub modulus: Integer,
 }
 
 /// ElGamal ciphertext of integers.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct IntegerElGamalCiphertext {
-    pub(crate) c1: Integer,
-    pub(crate) c2: Integer,
+    /// First part of ciphertext
+    pub c1: Integer,
+    /// Second part of ciphertext
+    pub c2: Integer,
 }
 
 impl Associable<IntegerElGamalPK> for IntegerElGamalCiphertext {}

--- a/scicrypt-he/src/cryptosystems/paillier.rs
+++ b/scicrypt-he/src/cryptosystems/paillier.rs
@@ -7,6 +7,7 @@ use scicrypt_traits::homomorphic::HomomorphicAddition;
 use scicrypt_traits::randomness::GeneralRng;
 use scicrypt_traits::randomness::SecureRng;
 use scicrypt_traits::security::BitsOfSecurity;
+use serde::{Deserialize, Serialize};
 use std::ops::Rem;
 
 /// The Paillier cryptosystem.
@@ -16,12 +17,13 @@ pub struct Paillier {
 }
 
 /// Public key for the Paillier cryptosystem.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct PaillierPK {
-    n: Integer,
-    g: Integer,
+    /// Public modulus n for encryption
+    pub n: Integer,
+    /// Public generator g for encryption
+    pub g: Integer,
 }
-
 /// Decryption key for the Paillier cryptosystem.
 pub struct PaillierSK {
     lambda: Integer,
@@ -29,8 +31,10 @@ pub struct PaillierSK {
 }
 
 /// Ciphertext of the Paillier cryptosystem, which is additively homomorphic.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct PaillierCiphertext {
-    pub(crate) c: Integer,
+    /// Encrypted message (Ciphertext)
+    pub c: Integer,
 }
 
 impl Associable<PaillierPK> for PaillierCiphertext {}

--- a/scicrypt-he/src/cryptosystems/rsa.rs
+++ b/scicrypt-he/src/cryptosystems/rsa.rs
@@ -7,6 +7,7 @@ use scicrypt_traits::homomorphic::HomomorphicMultiplication;
 use scicrypt_traits::randomness::GeneralRng;
 use scicrypt_traits::randomness::SecureRng;
 use scicrypt_traits::security::BitsOfSecurity;
+use serde::{Deserialize, Serialize};
 use std::ops::Rem;
 
 /// The RSA cryptosystem.
@@ -16,10 +17,12 @@ pub struct Rsa {
 }
 
 /// Public key for the RSA cryptosystem.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct RsaPK {
-    n: Integer,
-    e: Integer,
+    /// Public modulus
+    pub n: Integer,
+    /// Public exponentation factor
+    pub e: Integer,
 }
 
 /// Decryption key for RSA
@@ -28,8 +31,10 @@ pub struct RsaSK {
 }
 
 /// Ciphertext of the RSA cryptosystem, which is multiplicatively homomorphic.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct RsaCiphertext {
-    c: Integer,
+    /// Ciphertext as an Integer
+    pub c: Integer,
 }
 
 impl Associable<RsaPK> for RsaCiphertext {}
@@ -94,8 +99,10 @@ impl HomomorphicMultiplication for RsaPK {
     }
 }
 /// Signature of the RSA cryptosystem
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct RsaSignature {
-    s: Integer,
+    /// Signature as an Integer
+    pub s: Integer,
 }
 
 impl VerificationKey for RsaPK {


### PR DESCRIPTION
This PR adds serde support for the public keys and ciphertexts that allows these to be sent between parties using channels. In particular, all cryptosystems (not the threshold ones) derive/implement the serde traits:
- Added serde traits for RSA, Paillier & Integer-El-Gamal
- Added custom serialize/deserialize function for Curve-El-Gamal to only send the basepoint but reconstruct the multiplication table when deserializing. This saves a bit of data to be sent
- Made fields of public keys and ciphertext public. This is useful e.g. when needing access to the generators g or raw Integer values of ciphertexts or public keys

I am not entirely convinced that making the fields public is the best way. I could also imagine just implementing getter methods to get the parameters, but that is a bit more involved.