### PR TITLE
Implement homomorphic operations for references

### DIFF
--- a/scicrypt-he/src/cryptosystems/curve_el_gamal.rs
+++ b/scicrypt-he/src/cryptosystems/curve_el_gamal.rs
@@ -191,8 +191,8 @@ impl DecryptionKey<PrecomputedCurveElGamalPK> for CurveElGamalSK {
 impl HomomorphicAddition for CurveElGamalPK {
     fn add(
         &self,
-        ciphertext_a: Self::Ciphertext,
-        ciphertext_b: Self::Ciphertext,
+        ciphertext_a: &Self::Ciphertext,
+        ciphertext_b: &Self::Ciphertext,
     ) -> Self::Ciphertext {
         CurveElGamalCiphertext {
             c1: ciphertext_a.c1 + ciphertext_b.c1,
@@ -200,7 +200,7 @@ impl HomomorphicAddition for CurveElGamalPK {
         }
     }
 
-    fn mul_constant(&self, ciphertext: Self::Ciphertext, input: Self::Input) -> Self::Ciphertext {
+    fn mul_constant(&self, ciphertext: &Self::Ciphertext, input: &Self::Input) -> Self::Ciphertext {
         CurveElGamalCiphertext {
             c1: ciphertext.c1 * input,
             c2: ciphertext.c2 * input,
@@ -209,8 +209,8 @@ impl HomomorphicAddition for CurveElGamalPK {
 
     fn sub(
         &self,
-        ciphertext_a: Self::Ciphertext,
-        ciphertext_b: Self::Ciphertext,
+        ciphertext_a: &Self::Ciphertext,
+        ciphertext_b: &Self::Ciphertext,
     ) -> Self::Ciphertext {
         CurveElGamalCiphertext {
             c1: ciphertext_a.c1 - ciphertext_b.c1,
@@ -220,7 +220,7 @@ impl HomomorphicAddition for CurveElGamalPK {
 
     fn add_constant(
         &self,
-        ciphertext: Self::Ciphertext,
+        ciphertext: &Self::Ciphertext,
         constant: &Self::Plaintext,
     ) -> Self::Ciphertext {
         CurveElGamalCiphertext {
@@ -231,7 +231,7 @@ impl HomomorphicAddition for CurveElGamalPK {
 
     fn sub_constant(
         &self,
-        ciphertext: Self::Ciphertext,
+        ciphertext: &Self::Ciphertext,
         constant: &Self::Plaintext,
     ) -> Self::Ciphertext {
         CurveElGamalCiphertext {
@@ -244,8 +244,8 @@ impl HomomorphicAddition for CurveElGamalPK {
 impl HomomorphicAddition for PrecomputedCurveElGamalPK {
     fn add(
         &self,
-        ciphertext_a: Self::Ciphertext,
-        ciphertext_b: Self::Ciphertext,
+        ciphertext_a: &Self::Ciphertext,
+        ciphertext_b: &Self::Ciphertext,
     ) -> Self::Ciphertext {
         CurveElGamalCiphertext {
             c1: ciphertext_a.c1 + ciphertext_b.c1,
@@ -253,7 +253,7 @@ impl HomomorphicAddition for PrecomputedCurveElGamalPK {
         }
     }
 
-    fn mul_constant(&self, ciphertext: Self::Ciphertext, input: Self::Input) -> Self::Ciphertext {
+    fn mul_constant(&self, ciphertext: &Self::Ciphertext, input: &Self::Input) -> Self::Ciphertext {
         CurveElGamalCiphertext {
             c1: ciphertext.c1 * input,
             c2: ciphertext.c2 * input,
@@ -262,8 +262,8 @@ impl HomomorphicAddition for PrecomputedCurveElGamalPK {
 
     fn sub(
         &self,
-        ciphertext_a: Self::Ciphertext,
-        ciphertext_b: Self::Ciphertext,
+        ciphertext_a: &Self::Ciphertext,
+        ciphertext_b: &Self::Ciphertext,
     ) -> Self::Ciphertext {
         CurveElGamalCiphertext {
             c1: ciphertext_a.c1 - ciphertext_b.c1,
@@ -273,7 +273,7 @@ impl HomomorphicAddition for PrecomputedCurveElGamalPK {
 
     fn add_constant(
         &self,
-        ciphertext: Self::Ciphertext,
+        ciphertext: &Self::Ciphertext,
         constant: &Self::Plaintext,
     ) -> Self::Ciphertext {
         CurveElGamalCiphertext {
@@ -284,7 +284,7 @@ impl HomomorphicAddition for PrecomputedCurveElGamalPK {
 
     fn sub_constant(
         &self,
-        ciphertext: Self::Ciphertext,
+        ciphertext: &Self::Ciphertext,
         constant: &Self::Plaintext,
     ) -> Self::Ciphertext {
         CurveElGamalCiphertext {
@@ -351,7 +351,7 @@ mod tests {
 
         let ciphertext_a = pk.encrypt(&RISTRETTO_BASEPOINT_POINT, &mut rng);
         let ciphertext_b = pk.encrypt(&RISTRETTO_BASEPOINT_POINT, &mut rng);
-        let ciphertext_twice = ciphertext_a + ciphertext_b;
+        let ciphertext_twice = &ciphertext_a + &ciphertext_b;
 
         assert_eq!(
             &Scalar::from(2u64) * &RISTRETTO_BASEPOINT_POINT,
@@ -374,7 +374,7 @@ mod tests {
             &(&Scalar::from(3u64) * &RISTRETTO_BASEPOINT_POINT),
             &mut rng,
         );
-        let ciphertext_res = ciphertext_a - ciphertext_b;
+        let ciphertext_res = &ciphertext_a - &ciphertext_b;
 
         assert_eq!(
             &Scalar::from(2u64) * &RISTRETTO_BASEPOINT_POINT,
@@ -390,7 +390,7 @@ mod tests {
         let (pk, sk) = el_gamal.generate_keys(&mut rng);
 
         let ciphertext = pk.encrypt(&RISTRETTO_BASEPOINT_POINT, &mut rng);
-        let ciphertext_twice = ciphertext + &RISTRETTO_BASEPOINT_POINT;
+        let ciphertext_twice = &ciphertext + &RISTRETTO_BASEPOINT_POINT;
 
         assert_eq!(
             &Scalar::from(2u64) * &RISTRETTO_BASEPOINT_POINT,
@@ -409,7 +409,7 @@ mod tests {
             &(&Scalar::from(5u64) * &RISTRETTO_BASEPOINT_POINT),
             &mut rng,
         );
-        let ciphertext_res = ciphertext - &(&Scalar::from(3u64) * &RISTRETTO_BASEPOINT_POINT);
+        let ciphertext_res = &ciphertext - &(&Scalar::from(3u64) * &RISTRETTO_BASEPOINT_POINT);
 
         assert_eq!(
             &Scalar::from(2u64) * &RISTRETTO_BASEPOINT_POINT,
@@ -425,7 +425,7 @@ mod tests {
         let (pk, sk) = el_gamal.generate_keys(&mut rng);
 
         let ciphertext = pk.encrypt(&RISTRETTO_BASEPOINT_POINT, &mut rng);
-        let ciphertext_thrice = ciphertext * Scalar::from(3u64);
+        let ciphertext_thrice = &ciphertext * &Scalar::from(3u64);
 
         assert_eq!(
             &Scalar::from(3u64) * &RISTRETTO_BASEPOINT_POINT,

--- a/scicrypt-he/src/cryptosystems/integer_el_gamal.rs
+++ b/scicrypt-he/src/cryptosystems/integer_el_gamal.rs
@@ -27,7 +27,7 @@ use std::ops::Rem;
 /// let ciphertext_1 = public_key.encrypt(&Integer::from(4), &mut rng);
 /// let ciphertext_2 = public_key.encrypt(&Integer::from(6), &mut rng);
 ///
-/// println!("[4] * [6] = [{}]", secret_key.decrypt(&(ciphertext_1 * ciphertext_2)));
+/// println!("[4] * [6] = [{}]", secret_key.decrypt(&(&ciphertext_1 * &ciphertext_2)));
 /// // Prints: "[4] * [6] = [24]".
 /// ```
 #[derive(Clone)]
@@ -193,8 +193,8 @@ impl DecryptionKey<IntegerElGamalPK> for IntegerElGamalSK {
 impl HomomorphicMultiplication for IntegerElGamalPK {
     fn mul(
         &self,
-        ciphertext_a: Self::Ciphertext,
-        ciphertext_b: Self::Ciphertext,
+        ciphertext_a: &Self::Ciphertext,
+        ciphertext_b: &Self::Ciphertext,
     ) -> Self::Ciphertext {
         IntegerElGamalCiphertext {
             c1: Integer::from(&ciphertext_a.c1 * &ciphertext_b.c1).rem(&self.modulus),
@@ -202,10 +202,10 @@ impl HomomorphicMultiplication for IntegerElGamalPK {
         }
     }
 
-    fn pow(&self, ciphertext: Self::Ciphertext, input: Self::Input) -> Self::Ciphertext {
+    fn pow(&self, ciphertext: &Self::Ciphertext, input: &Self::Input) -> Self::Ciphertext {
         IntegerElGamalCiphertext {
-            c1: Integer::from(ciphertext.c1.pow_mod_ref(&input, &self.modulus).unwrap()),
-            c2: Integer::from(ciphertext.c2.pow_mod_ref(&input, &self.modulus).unwrap()),
+            c1: Integer::from(ciphertext.c1.pow_mod_ref(input, &self.modulus).unwrap()),
+            c2: Integer::from(ciphertext.c2.pow_mod_ref(input, &self.modulus).unwrap()),
         }
     }
 }
@@ -251,7 +251,7 @@ mod tests {
 
         let ciphertext_a = pk.encrypt(&Integer::from(7), &mut rng);
         let ciphertext_b = pk.encrypt(&Integer::from(7), &mut rng);
-        let ciphertext_twice = ciphertext_a * ciphertext_b;
+        let ciphertext_twice = &ciphertext_a * &ciphertext_b;
 
         assert_eq!(49, sk.decrypt(&ciphertext_twice));
     }
@@ -264,7 +264,7 @@ mod tests {
         let (pk, sk) = el_gamal.generate_keys(&mut rng);
 
         let ciphertext = pk.encrypt(&Integer::from(9), &mut rng);
-        let ciphertext_twice = ciphertext.pow(Integer::from(4));
+        let ciphertext_twice = ciphertext.pow(&Integer::from(4));
 
         assert_eq!(6561, sk.decrypt(&ciphertext_twice));
     }

--- a/scicrypt-he/src/cryptosystems/paillier.rs
+++ b/scicrypt-he/src/cryptosystems/paillier.rs
@@ -169,8 +169,10 @@ impl HomomorphicAddition for PaillierPK {
     ) -> Self::Ciphertext {
         let modulus = Integer::from(self.n.square_ref());
         PaillierCiphertext {
-            c: Integer::from(&ciphertext_a.c * &Integer::from(ciphertext_b.c.invert_ref(&modulus).unwrap()))
-                .rem(Integer::from(self.n.square_ref())),
+            c: Integer::from(
+                &ciphertext_a.c * &Integer::from(ciphertext_b.c.invert_ref(&modulus).unwrap()),
+            )
+            .rem(Integer::from(self.n.square_ref())),
         }
     }
 

--- a/scicrypt-he/src/cryptosystems/paillier.rs
+++ b/scicrypt-he/src/cryptosystems/paillier.rs
@@ -145,8 +145,8 @@ impl DecryptionKey<PaillierPK> for PaillierSK {
 impl HomomorphicAddition for PaillierPK {
     fn add(
         &self,
-        ciphertext_a: Self::Ciphertext,
-        ciphertext_b: Self::Ciphertext,
+        ciphertext_a: &Self::Ciphertext,
+        ciphertext_b: &Self::Ciphertext,
     ) -> Self::Ciphertext {
         PaillierCiphertext {
             c: Integer::from(&ciphertext_a.c * &ciphertext_b.c)
@@ -154,29 +154,29 @@ impl HomomorphicAddition for PaillierPK {
         }
     }
 
-    fn mul_constant(&self, ciphertext: Self::Ciphertext, input: Self::Input) -> Self::Ciphertext {
+    fn mul_constant(&self, ciphertext: &Self::Ciphertext, input: &Self::Input) -> Self::Ciphertext {
         let modulus = Integer::from(self.n.square_ref());
 
         PaillierCiphertext {
-            c: Integer::from(ciphertext.c.pow_mod_ref(&input, &modulus).unwrap()),
+            c: Integer::from(ciphertext.c.pow_mod_ref(input, &modulus).unwrap()),
         }
     }
 
     fn sub(
         &self,
-        ciphertext_a: Self::Ciphertext,
-        ciphertext_b: Self::Ciphertext,
+        ciphertext_a: &Self::Ciphertext,
+        ciphertext_b: &Self::Ciphertext,
     ) -> Self::Ciphertext {
         let modulus = Integer::from(self.n.square_ref());
         PaillierCiphertext {
-            c: Integer::from(&ciphertext_a.c * &ciphertext_b.c.invert(&modulus).unwrap())
+            c: Integer::from(&ciphertext_a.c * &Integer::from(ciphertext_b.c.invert_ref(&modulus).unwrap()))
                 .rem(Integer::from(self.n.square_ref())),
         }
     }
 
     fn add_constant(
         &self,
-        ciphertext: Self::Ciphertext,
+        ciphertext: &Self::Ciphertext,
         constant: &Self::Plaintext,
     ) -> Self::Ciphertext {
         let modulus = Integer::from(self.n.square_ref());
@@ -190,7 +190,7 @@ impl HomomorphicAddition for PaillierPK {
 
     fn sub_constant(
         &self,
-        ciphertext: Self::Ciphertext,
+        ciphertext: &Self::Ciphertext,
         constant: &Self::Plaintext,
     ) -> Self::Ciphertext {
         let modulus = Integer::from(self.n.square_ref());
@@ -250,7 +250,7 @@ mod tests {
 
         let ciphertext_a = pk.encrypt(&Integer::from(7), &mut rng);
         let ciphertext_b = pk.encrypt(&Integer::from(7), &mut rng);
-        let ciphertext_twice = ciphertext_a + ciphertext_b;
+        let ciphertext_twice = &ciphertext_a + &ciphertext_b;
 
         assert_eq!(Integer::from(14), sk.decrypt(&ciphertext_twice));
     }
@@ -264,7 +264,7 @@ mod tests {
 
         let ciphertext_a = pk.encrypt(&Integer::from(7), &mut rng);
         let ciphertext_b = pk.encrypt(&Integer::from(5), &mut rng);
-        let ciphertext_res = ciphertext_a - ciphertext_b;
+        let ciphertext_res = &ciphertext_a - &ciphertext_b;
 
         assert_eq!(Integer::from(2), sk.decrypt(&ciphertext_res));
     }
@@ -277,7 +277,7 @@ mod tests {
         let (pk, sk) = paillier.generate_keys(&mut rng);
 
         let ciphertext = pk.encrypt(&Integer::from(9), &mut rng);
-        let ciphertext_twice = ciphertext * Integer::from(16);
+        let ciphertext_twice = &ciphertext * &Integer::from(16);
 
         assert_eq!(144, sk.decrypt(&ciphertext_twice));
     }
@@ -290,7 +290,7 @@ mod tests {
         let (pk, sk) = paillier.generate_keys(&mut rng);
 
         let ciphertext = pk.encrypt(&Integer::from(7), &mut rng);
-        let ciphertext_res = ciphertext + &Integer::from(5);
+        let ciphertext_res = &ciphertext + &Integer::from(5);
 
         assert_eq!(Integer::from(12), sk.decrypt(&ciphertext_res));
     }
@@ -303,7 +303,7 @@ mod tests {
         let (pk, sk) = paillier.generate_keys(&mut rng);
 
         let ciphertext = pk.encrypt(&Integer::from(7), &mut rng);
-        let ciphertext_res = ciphertext - &Integer::from(5);
+        let ciphertext_res = &ciphertext - &Integer::from(5);
 
         assert_eq!(Integer::from(2), sk.decrypt(&ciphertext_res));
     }

--- a/scicrypt-he/src/cryptosystems/rsa.rs
+++ b/scicrypt-he/src/cryptosystems/rsa.rs
@@ -93,17 +93,17 @@ impl DecryptionKey<RsaPK> for RsaSK {
 impl HomomorphicMultiplication for RsaPK {
     fn mul(
         &self,
-        ciphertext_a: Self::Ciphertext,
-        ciphertext_b: Self::Ciphertext,
+        ciphertext_a: &Self::Ciphertext,
+        ciphertext_b: &Self::Ciphertext,
     ) -> Self::Ciphertext {
         RsaCiphertext {
             c: Integer::from(&ciphertext_a.c * &ciphertext_b.c).rem(&self.n),
         }
     }
 
-    fn pow(&self, ciphertext: Self::Ciphertext, input: Self::Input) -> Self::Ciphertext {
+    fn pow(&self, ciphertext: &Self::Ciphertext, input: &Self::Input) -> Self::Ciphertext {
         RsaCiphertext {
-            c: Integer::from(ciphertext.c.pow_mod_ref(&input, &self.n).unwrap()),
+            c: Integer::from(ciphertext.c.pow_mod_ref(input, &self.n).unwrap()),
         }
     }
 }
@@ -180,7 +180,7 @@ mod tests {
 
         let ciphertext_a = pk.encrypt(&Integer::from(7), &mut rng);
         let ciphertext_b = pk.encrypt(&Integer::from(7), &mut rng);
-        let ciphertext_twice = ciphertext_a * ciphertext_b;
+        let ciphertext_twice = &ciphertext_a * &ciphertext_b;
 
         assert_eq!(49, sk.decrypt(&ciphertext_twice));
     }
@@ -193,7 +193,7 @@ mod tests {
         let (pk, sk) = rsa.generate_keys(&mut rng);
 
         let ciphertext = pk.encrypt(&Integer::from(9), &mut rng);
-        let ciphertext_twice = ciphertext.pow(Integer::from(4));
+        let ciphertext_twice = ciphertext.pow(&Integer::from(4));
 
         assert_eq!(Integer::from(6561), sk.decrypt(&ciphertext_twice));
     }

--- a/scicrypt-traits/src/homomorphic.rs
+++ b/scicrypt-traits/src/homomorphic.rs
@@ -119,22 +119,23 @@ pub trait HomomorphicMultiplication: EncryptionKey {
     /// Combines two ciphertexts so that their decrypted value reflects some multiplication operation
     fn mul(
         &self,
-        ciphertext_a: Self::Ciphertext,
-        ciphertext_b: Self::Ciphertext,
+        ciphertext_a: &Self::Ciphertext,
+        ciphertext_b: &Self::Ciphertext,
     ) -> Self::Ciphertext;
+
     /// Applies some operation on a ciphertext so that the decrypted value reflects some exponentiation with `input`
-    fn pow(&self, ciphertext: Self::Ciphertext, input: Self::Input) -> Self::Ciphertext;
+    fn pow(&self, ciphertext: &Self::Ciphertext, input: &Self::Input) -> Self::Ciphertext;
 }
 
 impl<'pk, C: Associable<PK>, PK: EncryptionKey<Ciphertext = C> + HomomorphicMultiplication> Mul
-    for AssociatedCiphertext<'pk, C, PK>
+    for &AssociatedCiphertext<'pk, C, PK>
 {
     type Output = AssociatedCiphertext<'pk, C, PK>;
 
     fn mul(self, rhs: Self) -> Self::Output {
         debug_assert_eq!(self.public_key, rhs.public_key);
         self.public_key
-            .mul(self.ciphertext, rhs.ciphertext)
+            .mul(&self.ciphertext, &rhs.ciphertext)
             .associate(self.public_key)
     }
 }
@@ -143,9 +144,9 @@ impl<'pk, C: Associable<PK>, PK: EncryptionKey<Ciphertext = C> + HomomorphicMult
     AssociatedCiphertext<'pk, C, PK>
 {
     /// Applies some operation on this ciphertext so that the decrypted value reflects some exponentiation with `input`
-    pub fn pow(self, rhs: PK::Input) -> AssociatedCiphertext<'pk, C, PK> {
+    pub fn pow(&self, rhs: &PK::Input) -> AssociatedCiphertext<'pk, C, PK> {
         self.public_key
-            .pow(self.ciphertext, rhs)
+            .pow(&self.ciphertext, rhs)
             .associate(self.public_key)
     }
 }

--- a/scicrypt-traits/src/homomorphic.rs
+++ b/scicrypt-traits/src/homomorphic.rs
@@ -53,8 +53,12 @@ impl<'pk, C: Associable<PK>, PK: EncryptionKey<Ciphertext = C> + HomomorphicAddi
     }
 }
 
-impl<'pk, P: PotentialInput, C: Associable<PK>, PK: EncryptionKey<Ciphertext = C, Plaintext = P> + HomomorphicAddition>
-    Add<&P> for &AssociatedCiphertext<'pk, C, PK>
+impl<
+        'pk,
+        P: PotentialInput,
+        C: Associable<PK>,
+        PK: EncryptionKey<Ciphertext = C, Plaintext = P> + HomomorphicAddition,
+    > Add<&P> for &AssociatedCiphertext<'pk, C, PK>
 {
     type Output = AssociatedCiphertext<'pk, C, PK>;
 
@@ -78,8 +82,12 @@ impl<'pk, C: Associable<PK>, PK: EncryptionKey<Ciphertext = C> + HomomorphicAddi
     }
 }
 
-impl<'pk, P: PotentialInput, C: Associable<PK>, PK: EncryptionKey<Ciphertext = C, Plaintext = P> + HomomorphicAddition>
-    Sub<&P> for &AssociatedCiphertext<'pk, C, PK>
+impl<
+        'pk,
+        P: PotentialInput,
+        C: Associable<PK>,
+        PK: EncryptionKey<Ciphertext = C, Plaintext = P> + HomomorphicAddition,
+    > Sub<&P> for &AssociatedCiphertext<'pk, C, PK>
 {
     type Output = AssociatedCiphertext<'pk, C, PK>;
 

--- a/scicrypt-traits/src/homomorphic.rs
+++ b/scicrypt-traits/src/homomorphic.rs
@@ -11,81 +11,81 @@ pub trait HomomorphicAddition: EncryptionKey {
     /// Combines two ciphertexts so that their decrypted value reflects some addition operation
     fn add(
         &self,
-        ciphertext_a: Self::Ciphertext,
-        ciphertext_b: Self::Ciphertext,
+        ciphertext_a: &Self::Ciphertext,
+        ciphertext_b: &Self::Ciphertext,
     ) -> Self::Ciphertext;
 
     /// Combines two ciphertexts so that their decrypted value reflects some subtract operation
     fn sub(
         &self,
-        ciphertext_a: Self::Ciphertext,
-        ciphertext_b: Self::Ciphertext,
+        ciphertext_a: &Self::Ciphertext,
+        ciphertext_b: &Self::Ciphertext,
     ) -> Self::Ciphertext;
 
     /// Applies some operation on a ciphertext so that the decrypted value reflects some multiplication with `input`
-    fn mul_constant(&self, ciphertext: Self::Ciphertext, input: Self::Input) -> Self::Ciphertext;
+    fn mul_constant(&self, ciphertext: &Self::Ciphertext, input: &Self::Input) -> Self::Ciphertext;
 
     /// Combines two ciphertexts so that their decrypted value reflects some addition operation with a constant
     fn add_constant(
         &self,
-        ciphertext: Self::Ciphertext,
+        ciphertext: &Self::Ciphertext,
         constant: &Self::Plaintext,
     ) -> Self::Ciphertext;
 
     /// Combines two ciphertexts so that their decrypted value reflects some subtract operation with a constant
     fn sub_constant(
         &self,
-        ciphertext: Self::Ciphertext,
+        ciphertext: &Self::Ciphertext,
         constant: &Self::Plaintext,
     ) -> Self::Ciphertext;
 }
 
 impl<'pk, C: Associable<PK>, PK: EncryptionKey<Ciphertext = C> + HomomorphicAddition> Add
-    for AssociatedCiphertext<'pk, C, PK>
+    for &AssociatedCiphertext<'pk, C, PK>
 {
     type Output = AssociatedCiphertext<'pk, C, PK>;
 
     fn add(self, rhs: Self) -> Self::Output {
         debug_assert_eq!(self.public_key, rhs.public_key);
         self.public_key
-            .add(self.ciphertext, rhs.ciphertext)
+            .add(&self.ciphertext, &rhs.ciphertext)
             .associate(self.public_key)
     }
 }
 
-impl<'pk, C: Associable<PK>, PK: EncryptionKey<Ciphertext = C> + HomomorphicAddition>
-    Add<&PK::Plaintext> for AssociatedCiphertext<'pk, C, PK>
+impl<'pk, P: PotentialInput, C: Associable<PK>, PK: EncryptionKey<Ciphertext = C, Plaintext = P> + HomomorphicAddition>
+    Add<&P> for &AssociatedCiphertext<'pk, C, PK>
 {
     type Output = AssociatedCiphertext<'pk, C, PK>;
 
     fn add(self, rhs: &PK::Plaintext) -> Self::Output {
         self.public_key
-            .add_constant(self.ciphertext, rhs)
+            .add_constant(&self.ciphertext, rhs)
             .associate(self.public_key)
     }
 }
 
 impl<'pk, C: Associable<PK>, PK: EncryptionKey<Ciphertext = C> + HomomorphicAddition> Sub
-    for AssociatedCiphertext<'pk, C, PK>
+    for &AssociatedCiphertext<'pk, C, PK>
 {
     type Output = AssociatedCiphertext<'pk, C, PK>;
 
     fn sub(self, rhs: Self) -> Self::Output {
         debug_assert_eq!(self.public_key, rhs.public_key);
         self.public_key
-            .sub(self.ciphertext, rhs.ciphertext)
+            .sub(&self.ciphertext, &rhs.ciphertext)
             .associate(self.public_key)
     }
 }
 
-impl<'pk, C: Associable<PK>, PK: EncryptionKey<Ciphertext = C> + HomomorphicAddition>
-    Sub<&PK::Plaintext> for AssociatedCiphertext<'pk, C, PK>
+impl<'pk, P: PotentialInput, C: Associable<PK>, PK: EncryptionKey<Ciphertext = C, Plaintext = P> + HomomorphicAddition>
+    Sub<&P> for &AssociatedCiphertext<'pk, C, PK>
 {
     type Output = AssociatedCiphertext<'pk, C, PK>;
 
     fn sub(self, rhs: &PK::Plaintext) -> Self::Output {
         self.public_key
-            .sub_constant(self.ciphertext, rhs)
+            .sub_constant(&self.ciphertext, rhs)
             .associate(self.public_key)
     }
 }
@@ -95,13 +95,13 @@ impl<
         P: PotentialInput,
         C: Associable<PK>,
         PK: EncryptionKey<Input = P, Ciphertext = C> + HomomorphicAddition,
-    > Mul<P> for AssociatedCiphertext<'pk, C, PK>
+    > Mul<&P> for &AssociatedCiphertext<'pk, C, PK>
 {
     type Output = AssociatedCiphertext<'pk, C, PK>;
 
-    fn mul(self, rhs: PK::Input) -> Self::Output {
+    fn mul(self, rhs: &PK::Input) -> Self::Output {
         self.public_key
-            .mul_constant(self.ciphertext, rhs)
+            .mul_constant(&self.ciphertext, rhs)
             .associate(self.public_key)
     }
 }


### PR DESCRIPTION
Currently, the homomorphic operations take ownership of the ciphertexts, but this is typically not the intended effect. In the future we can consider supporting all combinations of references/taking ownership.