### PR TITLE
Added encrypt_deterministic & randomize function.

### DIFF
--- a/scicrypt-he/src/cryptosystems/curve_el_gamal.rs
+++ b/scicrypt-he/src/cryptosystems/curve_el_gamal.rs
@@ -102,29 +102,37 @@ impl EncryptionKey for CurveElGamalPK {
     type Input = Scalar;
     type Plaintext = RistrettoPoint;
     type Ciphertext = CurveElGamalCiphertext;
+    type Randomness = Scalar;
 
     fn encrypt_raw<R: SecureRng>(
         &self,
         plaintext: &RistrettoPoint,
         rng: &mut GeneralRng<R>,
     ) -> CurveElGamalCiphertext {
-        let y = Scalar::random(rng.rng());
+        let message = self.encrypt_without_randomness(plaintext);
 
-        let message = self.encrypt_determinstic(plaintext);
-
-        self.randomize(message, &y)
+        self.randomize(message, rng)
     }
-    fn encrypt_determinstic(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext {
+    fn encrypt_without_randomness(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext {
         CurveElGamalCiphertext {
             c1: identity(RISTRETTO_BASEPOINT_POINT),
             c2: plaintext.to_owned(),
         }
     }
 
-    fn randomize(
+    fn randomize<R: SecureRng>(
         &self,
         ciphertext: Self::Ciphertext,
-        randomness: &Self::Input,
+        rng: &mut GeneralRng<R>,
+    ) -> Self::Ciphertext {
+        let randomness = Scalar::random(rng.rng());
+
+        self.randomize_with(ciphertext, &randomness)
+    }
+    fn randomize_with(
+        &self,
+        ciphertext: Self::Ciphertext,
+        randomness: &Self::Randomness,
     ) -> Self::Ciphertext {
         CurveElGamalCiphertext {
             c1: randomness * &RISTRETTO_BASEPOINT_TABLE,
@@ -155,28 +163,37 @@ impl EncryptionKey for PrecomputedCurveElGamalPK {
     type Input = Scalar;
     type Plaintext = RistrettoPoint;
     type Ciphertext = CurveElGamalCiphertext;
+    type Randomness = Scalar;
 
     fn encrypt_raw<R: SecureRng>(
         &self,
         plaintext: &RistrettoPoint,
         rng: &mut GeneralRng<R>,
     ) -> CurveElGamalCiphertext {
-        let y = Scalar::random(rng.rng());
-        let message = self.encrypt_determinstic(plaintext);
+        let message = self.encrypt_without_randomness(plaintext);
 
-        self.randomize(message, &y)
+        self.randomize(message, rng)
     }
-    fn encrypt_determinstic(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext {
+    fn encrypt_without_randomness(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext {
         CurveElGamalCiphertext {
             c1: identity(RISTRETTO_BASEPOINT_POINT),
             c2: plaintext.to_owned(),
         }
     }
 
-    fn randomize(
+    fn randomize<R: SecureRng>(
         &self,
         ciphertext: Self::Ciphertext,
-        randomness: &Self::Input,
+        rng: &mut GeneralRng<R>,
+    ) -> Self::Ciphertext {
+        let randomness = Scalar::random(rng.rng());
+
+        self.randomize_with(ciphertext, &randomness)
+    }
+    fn randomize_with(
+        &self,
+        ciphertext: Self::Ciphertext,
+        randomness: &Self::Randomness,
     ) -> Self::Ciphertext {
         CurveElGamalCiphertext {
             c1: randomness * &RISTRETTO_BASEPOINT_TABLE,

--- a/scicrypt-he/src/cryptosystems/curve_el_gamal.rs
+++ b/scicrypt-he/src/cryptosystems/curve_el_gamal.rs
@@ -126,10 +126,10 @@ impl EncryptionKey for CurveElGamalPK {
         ciphertext: Self::Ciphertext,
         randomness: &Self::Input,
     ) -> Self::Ciphertext {
-        return CurveElGamalCiphertext {
+        CurveElGamalCiphertext {
             c1: randomness * &RISTRETTO_BASEPOINT_TABLE,
             c2: ciphertext.c2 + randomness * self.point,
-        };
+        }
     }
 }
 
@@ -178,10 +178,10 @@ impl EncryptionKey for PrecomputedCurveElGamalPK {
         ciphertext: Self::Ciphertext,
         randomness: &Self::Input,
     ) -> Self::Ciphertext {
-        return CurveElGamalCiphertext {
+        CurveElGamalCiphertext {
             c1: randomness * &RISTRETTO_BASEPOINT_TABLE,
             c2: ciphertext.c2 + randomness * &self.point,
-        };
+        }
     }
 }
 

--- a/scicrypt-he/src/cryptosystems/curve_el_gamal.rs
+++ b/scicrypt-he/src/cryptosystems/curve_el_gamal.rs
@@ -104,15 +104,6 @@ impl EncryptionKey for CurveElGamalPK {
     type Ciphertext = CurveElGamalCiphertext;
     type Randomness = Scalar;
 
-    fn encrypt_raw<R: SecureRng>(
-        &self,
-        plaintext: &RistrettoPoint,
-        rng: &mut GeneralRng<R>,
-    ) -> CurveElGamalCiphertext {
-        let message = self.encrypt_without_randomness(plaintext);
-
-        self.randomize(message, rng)
-    }
     fn encrypt_without_randomness(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext {
         CurveElGamalCiphertext {
             c1: identity(RISTRETTO_BASEPOINT_POINT),
@@ -129,6 +120,7 @@ impl EncryptionKey for CurveElGamalPK {
 
         self.randomize_with(ciphertext, &randomness)
     }
+
     fn randomize_with(
         &self,
         ciphertext: Self::Ciphertext,
@@ -165,15 +157,6 @@ impl EncryptionKey for PrecomputedCurveElGamalPK {
     type Ciphertext = CurveElGamalCiphertext;
     type Randomness = Scalar;
 
-    fn encrypt_raw<R: SecureRng>(
-        &self,
-        plaintext: &RistrettoPoint,
-        rng: &mut GeneralRng<R>,
-    ) -> CurveElGamalCiphertext {
-        let message = self.encrypt_without_randomness(plaintext);
-
-        self.randomize(message, rng)
-    }
     fn encrypt_without_randomness(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext {
         CurveElGamalCiphertext {
             c1: identity(RISTRETTO_BASEPOINT_POINT),
@@ -190,6 +173,7 @@ impl EncryptionKey for PrecomputedCurveElGamalPK {
 
         self.randomize_with(ciphertext, &randomness)
     }
+
     fn randomize_with(
         &self,
         ciphertext: Self::Ciphertext,

--- a/scicrypt-he/src/cryptosystems/integer_el_gamal.rs
+++ b/scicrypt-he/src/cryptosystems/integer_el_gamal.rs
@@ -136,11 +136,27 @@ impl EncryptionKey for IntegerElGamalPK {
         let q = Integer::from(&self.modulus >> 1);
         let y = q.random_below(&mut rng.rug_rng());
 
+        let message = self.encrypt_determinstic(plaintext);
+
+        self.randomize(message, &y)
+    }
+    fn encrypt_determinstic(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext {
         IntegerElGamalCiphertext {
-            c1: Integer::from(Integer::from(4).secure_pow_mod_ref(&y, &self.modulus)),
-            c2: (plaintext * Integer::from(self.h.secure_pow_mod_ref(&y, &self.modulus)))
-                .rem(&self.modulus),
+            c1: Integer::from(1),
+            c2: plaintext.to_owned().rem(&self.modulus),
         }
+    }
+    fn randomize(
+        &self,
+        ciphertext: Self::Ciphertext,
+        randomness: &Self::Input,
+    ) -> Self::Ciphertext {
+        return IntegerElGamalCiphertext {
+            c1: Integer::from(Integer::from(4).secure_pow_mod_ref(randomness, &self.modulus)),
+            c2: (ciphertext.c2
+                * Integer::from(self.h.secure_pow_mod_ref(randomness, &self.modulus)))
+            .rem(&self.modulus),
+        };
     }
 }
 

--- a/scicrypt-he/src/cryptosystems/integer_el_gamal.rs
+++ b/scicrypt-he/src/cryptosystems/integer_el_gamal.rs
@@ -6,7 +6,7 @@
 //! use scicrypt_traits::cryptosystems::{AsymmetricCryptosystem, EncryptionKey};
 //! use rand_core::OsRng;
 //! use rug::Integer;
-//! 
+//!
 //! let mut rng = GeneralRng::new(OsRng);
 //! let el_gamal = IntegerElGamal::setup(&Default::default());
 //! let (public_key, secret_key) = el_gamal.generate_keys(&mut rng);

--- a/scicrypt-he/src/cryptosystems/integer_el_gamal.rs
+++ b/scicrypt-he/src/cryptosystems/integer_el_gamal.rs
@@ -1,3 +1,18 @@
+//! Here is an example of how to generates a key pair and encrypt a plaintext integer using the ElGamal public key.
+//! ```
+//! use scicrypt_traits::randomness::GeneralRng;
+//! use scicrypt_he::cryptosystems::integer_el_gamal::IntegerElGamal;
+//! use scicrypt_traits::security::BitsOfSecurity;
+//! use scicrypt_traits::cryptosystems::{AsymmetricCryptosystem, EncryptionKey};
+//! use rand_core::OsRng;
+//! use rug::Integer;
+//! 
+//! let mut rng = GeneralRng::new(OsRng);
+//! let el_gamal = IntegerElGamal::setup(&Default::default());
+//! let (public_key, secret_key) = el_gamal.generate_keys(&mut rng);
+//! let ciphertext = public_key.encrypt(&Integer::from(5), &mut rng);
+//! ```
+
 use crate::constants::{SAFE_PRIME_1024, SAFE_PRIME_2048, SAFE_PRIME_3072};
 use rug::Integer;
 use scicrypt_traits::cryptosystems::{
@@ -115,20 +130,6 @@ impl EncryptionKey for IntegerElGamalPK {
     type Plaintext = Integer;
     type Ciphertext = IntegerElGamalCiphertext;
     type Randomness = Integer;
-
-    /// Encrypts an integer using the public key.
-    /// ```
-    /// # use scicrypt_traits::randomness::GeneralRng;
-    /// # use scicrypt_he::cryptosystems::integer_el_gamal::IntegerElGamal;
-    /// # use scicrypt_traits::security::BitsOfSecurity;
-    /// # use scicrypt_traits::cryptosystems::{AsymmetricCryptosystem, EncryptionKey};
-    /// # use rand_core::OsRng;
-    /// # use rug::Integer;
-    /// # let mut rng = GeneralRng::new(OsRng);
-    /// # let el_gamal = IntegerElGamal::setup(&Default::default());
-    /// # let (public_key, secret_key) = el_gamal.generate_keys(&mut rng);
-    /// let ciphertext = public_key.encrypt(&Integer::from(5), &mut rng);
-    /// ```
 
     fn encrypt_without_randomness(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext {
         IntegerElGamalCiphertext {

--- a/scicrypt-he/src/cryptosystems/integer_el_gamal.rs
+++ b/scicrypt-he/src/cryptosystems/integer_el_gamal.rs
@@ -151,12 +151,12 @@ impl EncryptionKey for IntegerElGamalPK {
         ciphertext: Self::Ciphertext,
         randomness: &Self::Input,
     ) -> Self::Ciphertext {
-        return IntegerElGamalCiphertext {
+        IntegerElGamalCiphertext {
             c1: Integer::from(Integer::from(4).secure_pow_mod_ref(randomness, &self.modulus)),
             c2: (ciphertext.c2
                 * Integer::from(self.h.secure_pow_mod_ref(randomness, &self.modulus)))
             .rem(&self.modulus),
-        };
+        }
     }
 }
 

--- a/scicrypt-he/src/cryptosystems/integer_el_gamal.rs
+++ b/scicrypt-he/src/cryptosystems/integer_el_gamal.rs
@@ -136,6 +136,7 @@ impl EncryptionKey for IntegerElGamalPK {
             c2: plaintext.to_owned().rem(&self.modulus),
         }
     }
+
     fn randomize<R: SecureRng>(
         &self,
         ciphertext: Self::Ciphertext,
@@ -146,6 +147,7 @@ impl EncryptionKey for IntegerElGamalPK {
 
         self.randomize_with(ciphertext, &y)
     }
+
     fn randomize_with(
         &self,
         ciphertext: Self::Ciphertext,

--- a/scicrypt-he/src/cryptosystems/paillier.rs
+++ b/scicrypt-he/src/cryptosystems/paillier.rs
@@ -6,7 +6,7 @@
 //! use scicrypt_traits::cryptosystems::{AsymmetricCryptosystem, EncryptionKey};
 //! use rug::Integer;
 //! use rand_core::OsRng;
-//! 
+//!
 //! let mut rng = GeneralRng::new(OsRng);
 //! let paillier = Paillier::setup(&BitsOfSecurity::ToyParameters);
 //! let (public_key, secret_key) = paillier.generate_keys(&mut rng);

--- a/scicrypt-he/src/cryptosystems/paillier.rs
+++ b/scicrypt-he/src/cryptosystems/paillier.rs
@@ -1,3 +1,18 @@
+//! Here is an example of how to generates a key pair and encrypt a plaintext integer using the Paillier public key.
+//! ```
+//! use scicrypt_traits::randomness::GeneralRng;
+//! use scicrypt_he::cryptosystems::paillier::Paillier;
+//! use scicrypt_traits::security::BitsOfSecurity;
+//! use scicrypt_traits::cryptosystems::{AsymmetricCryptosystem, EncryptionKey};
+//! use rug::Integer;
+//! use rand_core::OsRng;
+//! 
+//! let mut rng = GeneralRng::new(OsRng);
+//! let paillier = Paillier::setup(&BitsOfSecurity::ToyParameters);
+//! let (public_key, secret_key) = paillier.generate_keys(&mut rng);
+//! let ciphertext = public_key.encrypt(&Integer::from(5), &mut rng);
+//! ```
+
 use rug::Integer;
 use scicrypt_numbertheory::{gen_coprime, gen_rsa_modulus};
 use scicrypt_traits::cryptosystems::{
@@ -75,20 +90,6 @@ impl EncryptionKey for PaillierPK {
     type Plaintext = Integer;
     type Ciphertext = PaillierCiphertext;
     type Randomness = Integer;
-
-    /// Encrypts a plaintext integer using the Paillier public key.
-    /// ```
-    /// # use scicrypt_traits::randomness::GeneralRng;
-    /// # use scicrypt_he::cryptosystems::paillier::Paillier;
-    /// # use scicrypt_traits::security::BitsOfSecurity;
-    /// # use scicrypt_traits::cryptosystems::{AsymmetricCryptosystem, EncryptionKey};
-    /// # use rug::Integer;
-    /// # use rand_core::OsRng;
-    /// # let mut rng = GeneralRng::new(OsRng);
-    /// # let paillier = Paillier::setup(&BitsOfSecurity::ToyParameters);
-    /// # let (public_key, secret_key) = paillier.generate_keys(&mut rng);
-    /// let ciphertext = public_key.encrypt(&Integer::from(5), &mut rng);
-    /// ```
 
     fn encrypt_without_randomness(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext {
         let n_squared = Integer::from(self.n.square_ref());

--- a/scicrypt-he/src/cryptosystems/paillier.rs
+++ b/scicrypt-he/src/cryptosystems/paillier.rs
@@ -75,6 +75,7 @@ impl EncryptionKey for PaillierPK {
     type Plaintext = Integer;
     type Ciphertext = PaillierCiphertext;
     type Randomness = Integer;
+
     /// Encrypts a plaintext integer using the Paillier public key.
     /// ```
     /// # use scicrypt_traits::randomness::GeneralRng;
@@ -95,6 +96,7 @@ impl EncryptionKey for PaillierPK {
             c: Integer::from(self.g.pow_mod_ref(&plaintext.into(), &n_squared).unwrap()),
         }
     }
+
     fn randomize<R: SecureRng>(
         &self,
         ciphertext: Self::Ciphertext,
@@ -105,6 +107,7 @@ impl EncryptionKey for PaillierPK {
 
         self.randomize_with(ciphertext, &r)
     }
+
     fn randomize_with(
         &self,
         ciphertext: Self::Ciphertext,

--- a/scicrypt-he/src/cryptosystems/paillier.rs
+++ b/scicrypt-he/src/cryptosystems/paillier.rs
@@ -116,9 +116,9 @@ impl EncryptionKey for PaillierPK {
 
         let randomizer = randomness.to_owned().secure_pow_mod(&self.n, &n_squared);
 
-        return PaillierCiphertext {
+        PaillierCiphertext {
             c: Integer::from(&ciphertext.c * &randomizer).rem(n_squared),
-        };
+        }
     }
 }
 

--- a/scicrypt-he/src/cryptosystems/rsa.rs
+++ b/scicrypt-he/src/cryptosystems/rsa.rs
@@ -78,6 +78,7 @@ impl EncryptionKey for RsaPK {
             c: Integer::from(plaintext.pow_mod_ref(&self.e, &self.n).unwrap()),
         }
     }
+
     fn randomize<R: SecureRng>(
         &self,
         _ciphertext: Self::Ciphertext,
@@ -85,6 +86,7 @@ impl EncryptionKey for RsaPK {
     ) -> Self::Ciphertext {
         panic!("Not possible to randomize Rsa ciphertext")
     }
+
     fn randomize_with(
         &self,
         _ciphertext: Self::Ciphertext,

--- a/scicrypt-he/src/cryptosystems/rsa.rs
+++ b/scicrypt-he/src/cryptosystems/rsa.rs
@@ -63,18 +63,34 @@ impl EncryptionKey for RsaPK {
     type Input = Integer;
     type Plaintext = Integer;
     type Ciphertext = RsaCiphertext;
+    type Randomness = Integer;
 
     fn encrypt_raw<R: SecureRng>(
         &self,
-        plaintext: &Integer,
+        plaintext: &Self::Plaintext,
         _rng: &mut GeneralRng<R>,
-    ) -> RsaCiphertext {
-        self.encrypt_determinstic(plaintext)
+    ) -> Self::Ciphertext {
+        self.encrypt_without_randomness(plaintext)
     }
-    fn encrypt_determinstic(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext {
+
+    fn encrypt_without_randomness(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext {
         RsaCiphertext {
             c: Integer::from(plaintext.pow_mod_ref(&self.e, &self.n).unwrap()),
         }
+    }
+    fn randomize<R: SecureRng>(
+        &self,
+        _ciphertext: Self::Ciphertext,
+        _rng: &mut GeneralRng<R>,
+    ) -> Self::Ciphertext {
+        panic!("Not possible to randomize Rsa ciphertext")
+    }
+    fn randomize_with(
+        &self,
+        _ciphertext: Self::Ciphertext,
+        _randomness: &Self::Randomness,
+    ) -> Self::Ciphertext {
+        panic!("Not possible to randomize Rsa ciphertext")
     }
 }
 

--- a/scicrypt-he/src/cryptosystems/rsa.rs
+++ b/scicrypt-he/src/cryptosystems/rsa.rs
@@ -69,7 +69,7 @@ impl EncryptionKey for RsaPK {
         plaintext: &Integer,
         _rng: &mut GeneralRng<R>,
     ) -> RsaCiphertext {
-        self.encrypt_determinstic(&plaintext)
+        self.encrypt_determinstic(plaintext)
     }
     fn encrypt_determinstic(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext {
         RsaCiphertext {

--- a/scicrypt-he/src/cryptosystems/rsa.rs
+++ b/scicrypt-he/src/cryptosystems/rsa.rs
@@ -69,6 +69,9 @@ impl EncryptionKey for RsaPK {
         plaintext: &Integer,
         _rng: &mut GeneralRng<R>,
     ) -> RsaCiphertext {
+        self.encrypt_determinstic(&plaintext)
+    }
+    fn encrypt_determinstic(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext {
         RsaCiphertext {
             c: Integer::from(plaintext.pow_mod_ref(&self.e, &self.n).unwrap()),
         }

--- a/scicrypt-he/src/threshold_cryptosystems/paillier.rs
+++ b/scicrypt-he/src/threshold_cryptosystems/paillier.rs
@@ -147,9 +147,9 @@ impl EncryptionKey for ThresholdPaillierPK {
             .to_owned()
             .secure_pow_mod(&self.modulus, &n_squared);
 
-        return PaillierCiphertext {
+        PaillierCiphertext {
             c: (ciphertext.c * randomizer).rem(&n_squared),
-        };
+        }
     }
 }
 

--- a/scicrypt-he/src/threshold_cryptosystems/paillier.rs
+++ b/scicrypt-he/src/threshold_cryptosystems/paillier.rs
@@ -110,24 +110,10 @@ impl EncryptionKey for ThresholdPaillierPK {
     type Input = Integer;
     type Plaintext = Integer;
     type Ciphertext = PaillierCiphertext;
+    type Randomness = Integer;
 
-    fn encrypt_raw<R: SecureRng>(
-        &self,
-        plaintext: &Integer,
-        rng: &mut GeneralRng<R>,
-    ) -> PaillierCiphertext
-    where
-        Self: Sized,
-    {
+    fn encrypt_without_randomness(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext {
         let n_squared = Integer::from(self.modulus.square_ref());
-        let r = gen_coprime(&n_squared, rng);
-
-        let ciphertext = self.encrypt_determinstic(plaintext);
-        self.randomize(ciphertext, &r)
-    }
-    fn encrypt_determinstic(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext {
-        let n_squared = Integer::from(self.modulus.square_ref());
-
         PaillierCiphertext {
             c: Integer::from(
                 self.generator
@@ -136,19 +122,28 @@ impl EncryptionKey for ThresholdPaillierPK {
             ),
         }
     }
-    fn randomize(
+    fn randomize<R: SecureRng>(
         &self,
         ciphertext: Self::Ciphertext,
-        randomness: &Self::Input,
+        rng: &mut GeneralRng<R>,
     ) -> Self::Ciphertext {
         let n_squared = Integer::from(self.modulus.square_ref());
+        let r = gen_coprime(&n_squared, rng);
 
+        self.randomize_with(ciphertext, &r)
+    }
+    fn randomize_with(
+        &self,
+        ciphertext: Self::Ciphertext,
+        randomness: &Self::Randomness,
+    ) -> Self::Ciphertext {
+        let n_squared = Integer::from(self.modulus.square_ref());
         let randomizer = randomness
             .to_owned()
             .secure_pow_mod(&self.modulus, &n_squared);
 
         PaillierCiphertext {
-            c: (ciphertext.c * randomizer).rem(&n_squared),
+            c: Integer::from(&ciphertext.c * &randomizer).rem(n_squared),
         }
     }
 }

--- a/scicrypt-traits/src/cryptosystems.rs
+++ b/scicrypt-traits/src/cryptosystems.rs
@@ -61,7 +61,7 @@ pub trait EncryptionKey: Sized + Debug + PartialEq {
         self.randomize(message, rng)
     }
 
-    /// Encrypt the plaintext using the public key and (WARNING!) determinstic randomness. Should be used directly with randomize to control randomness.
+    /// **WARNING: This is not a full encryption. The resulting ciphertext is completely insecure.** 'Encrypts' the plaintext using the public key deterministically, essentially creating a trivial ciphertext. The encryption is not secure until you call `randomize` or `randomize_with` with suitable randomness.
     fn encrypt_without_randomness(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext;
 
     /// Randomizes the ciphertext with the supplied rng.

--- a/scicrypt-traits/src/cryptosystems.rs
+++ b/scicrypt-traits/src/cryptosystems.rs
@@ -53,6 +53,19 @@ pub trait EncryptionKey: Sized + Debug + PartialEq {
         plaintext: &Self::Plaintext,
         rng: &mut GeneralRng<R>,
     ) -> Self::Ciphertext;
+
+    /// Encrypt the plaintext using the public key and (WARNING!) determinstic randomness. Should be used directly with randomize to control randomness.
+    fn encrypt_determinstic(&self, plaintext: &Self::Plaintext) -> Self::Ciphertext;
+
+    /// Randomizes the ciphertext using supplied randomness.
+    #[allow(unused_variables)]
+    fn randomize(
+        &self,
+        ciphertext: Self::Ciphertext,
+        randomness: &Self::Input,
+    ) -> Self::Ciphertext {
+        ciphertext
+    }
 }
 
 /// The decryption key.


### PR DESCRIPTION
This PR adds functions `encrypt_deterministic` and `randomize` to the cryptosystems. This is useful when you want to control the randomness used e.g. for zero-knowledge proofs, or if you just want to add fresh randomness to your ciphertexts. This should close #7 

Changes:
- Added functions `encrypt_deterministic` and `randomize` to `cryptosystems.rs`. The default implementation of randomize is just to release the original ciphertext again, which is useful for cryptosystems not relying on Randomness (RSA).
- Added the above mentioned functions to the cryptosystems.
- Optimized as much as possible the operations needed using 1 or 0 as the deterministic randomness which cancels out a lot of terms.

Problems:
- The default behavior of randomize is to just return the ciphertext, which is useful for RSA. However, this forces to use `#[allow(unused_variables)]` above `randomize` so that the compiler does not complain. Not sure if you have a better idea to fix that.