### PR TITLE
Fixed randomize + added tests.

### DIFF
--- a/scicrypt-he/src/cryptosystems/paillier.rs
+++ b/scicrypt-he/src/cryptosystems/paillier.rs
@@ -221,7 +221,9 @@ mod tests {
     use crate::cryptosystems::paillier::Paillier;
     use rand_core::OsRng;
     use scicrypt_bigint::UnsignedInteger;
-    use scicrypt_traits::cryptosystems::{AsymmetricCryptosystem, DecryptionKey, EncryptionKey};
+    use scicrypt_traits::cryptosystems::{
+        Associable, AsymmetricCryptosystem, DecryptionKey, EncryptionKey,
+    };
     use scicrypt_traits::randomness::GeneralRng;
     use scicrypt_traits::security::BitsOfSecurity;
 
@@ -314,5 +316,23 @@ mod tests {
         let ciphertext_res = &ciphertext - &UnsignedInteger::from(5);
 
         assert_eq!(UnsignedInteger::from(2), sk.decrypt(&ciphertext_res));
+    }
+
+    #[test]
+    fn test_randomize() {
+        let mut rng = GeneralRng::new(OsRng);
+
+        let paillier = Paillier::setup(&BitsOfSecurity::ToyParameters);
+        let (pk, sk) = paillier.generate_keys(&mut rng);
+
+        let ciphertext = pk.encrypt_raw(&UnsignedInteger::from(21), &mut rng);
+        let ciphertext_randomized = pk.randomize(ciphertext.clone(), &mut rng);
+
+        assert_ne!(ciphertext, ciphertext_randomized);
+
+        assert_eq!(
+            UnsignedInteger::from(21),
+            sk.decrypt(&ciphertext_randomized.associate(&pk))
+        );
     }
 }


### PR DESCRIPTION
This PR should fix #46.
- Fixed Curve-El-Gamal and Integer-El-Gamal to use the previous ciphertext
- Added tests for `randomize`